### PR TITLE
Ignore historical commits that violate commitlint

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,1 +1,10 @@
-module.exports = { extends: ["@commitlint/config-conventional"] };
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  ignores: [
+    (message = "") =>
+      [
+        "Fixed CI file, removed long line of password validation in settings.py",
+        "Update CI node:",
+      ].includes(message.trim()),
+  ],
+};


### PR DESCRIPTION
## Summary
- update commitlint configuration to skip known legacy commits that do not follow the conventional commit format

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fbb9318a88832d95a69194d2494ce5